### PR TITLE
Add attestation detail viewer and credential management enhancements

### DIFF
--- a/examples/server/server/routes/advanced.py
+++ b/examples/server/server/routes/advanced.py
@@ -507,8 +507,8 @@ def advanced_register_complete():
         if attestation_certificate_details is not None:
             credential_info['attestation_certificate'] = attestation_certificate_details
 
-        credentials.append(credential_info)
-        savekey(username, credentials)
+        if isinstance(response, Mapping):
+            credential_info['registration_response'] = make_json_safe(response)
 
         algo = auth_data.credential_data.public_key[3]
         algoname = ""
@@ -680,6 +680,11 @@ def advanced_register_complete():
 
         if attestation_certificate_details:
             rp_info["attestationCertificate"] = attestation_certificate_details
+
+        credential_info['relying_party'] = make_json_safe(rp_info)
+
+        credentials.append(credential_info)
+        savekey(username, credentials)
 
         return jsonify({
             "status": "OK",

--- a/examples/server/server/routes/simple.py
+++ b/examples/server/server/routes/simple.py
@@ -19,7 +19,7 @@ from ..attestation import (
     make_json_safe,
 )
 from ..config import app, basepath, server
-from ..storage import add_public_key_material, convert_bytes_for_json, extract_credential_data, readkey, savekey
+from ..storage import add_public_key_material, convert_bytes_for_json, delkey, extract_credential_data, readkey, savekey
 
 
 @app.route("/api/register/begin", methods=["POST"])
@@ -222,8 +222,22 @@ def authenticate_complete():
     })
 
 
-@app.route("/api/credentials", methods=["GET"])
+@app.route("/api/credentials", methods=["GET", "DELETE"])
 def list_credentials():
+    if request.method == "DELETE":
+        removed = 0
+        try:
+            for filename in os.listdir(basepath):
+                if not filename.endswith('_credential_data.pkl'):
+                    continue
+                username = filename.replace('_credential_data.pkl', '')
+                delkey(username)
+                removed += 1
+        except Exception:
+            pass
+
+        return jsonify({"status": "OK", "removed": removed})
+
     credentials: List[Dict[str, Any]] = []
 
     try:

--- a/examples/server/server/static/auth-advanced.js
+++ b/examples/server/server/static/auth-advanced.js
@@ -20,9 +20,56 @@ import {
     hideProgress
 } from './status.js';
 import { updateJsonEditor, getAdvancedCreateOptions, getAdvancedAssertOptions } from './json-editor.js';
+import { randomizeChallenge, randomizePrfEval, randomizeLargeBlobWrite } from './forms.js';
+import { randomizeUserIdentity } from './username.js';
 import { showRegistrationResultModal, loadSavedCredentials } from './credential-display.js';
 import { printRegistrationDebug, printAuthenticationDebug } from './auth-debug.js';
 import { state } from './state.js';
+
+function maybeRandomizeAdvancedRegistrationFields() {
+    const userIdInput = document.getElementById('user-id');
+    const userNameInput = document.getElementById('user-name');
+    if ((userIdInput && userIdInput.value.trim()) || (userNameInput && userNameInput.value.trim())) {
+        randomizeUserIdentity();
+    }
+
+    const challengeRegInput = document.getElementById('challenge-reg');
+    if (challengeRegInput && challengeRegInput.value.trim()) {
+        randomizeChallenge('reg');
+    }
+
+    const prfFirstReg = document.getElementById('prf-eval-first-reg');
+    if (prfFirstReg && prfFirstReg.value.trim()) {
+        randomizePrfEval('first', 'reg');
+    }
+
+    const prfSecondReg = document.getElementById('prf-eval-second-reg');
+    if (prfSecondReg && prfSecondReg.value.trim()) {
+        randomizePrfEval('second', 'reg');
+    }
+}
+
+function maybeRandomizeAdvancedAuthenticationFields() {
+    const challengeAuthInput = document.getElementById('challenge-auth');
+    if (challengeAuthInput && challengeAuthInput.value.trim()) {
+        randomizeChallenge('auth');
+    }
+
+    const prfFirstAuth = document.getElementById('prf-eval-first-auth');
+    if (prfFirstAuth && prfFirstAuth.value.trim()) {
+        randomizePrfEval('first', 'auth');
+    }
+
+    const prfSecondAuth = document.getElementById('prf-eval-second-auth');
+    if (prfSecondAuth && prfSecondAuth.value.trim()) {
+        randomizePrfEval('second', 'auth');
+    }
+
+    const largeBlobWriteInput = document.getElementById('large-blob-write');
+    if (largeBlobWriteInput && largeBlobWriteInput.value.trim()) {
+        randomizeLargeBlobWrite();
+    }
+}
 
 const COMMON_SUPPORTED_ALGORITHMS = new Set([-7, -257, -8]);
 
@@ -206,6 +253,8 @@ export async function advancedRegister() {
 
             showStatus('advanced', `Advanced registration successful! Algorithm: ${data.algo || 'Unknown'}`, 'success');
 
+            maybeRandomizeAdvancedRegistrationFields();
+
             await showRegistrationResultModal(credentialJson, data.relyingParty || null);
 
             setTimeout(loadSavedCredentials, 1000);
@@ -336,6 +385,8 @@ export async function advancedAuthenticate() {
             printAuthenticationDebug(assertion, assertOptions, data);
 
             showStatus('advanced', 'Advanced authentication successful!', 'success');
+
+            maybeRandomizeAdvancedAuthenticationFields();
         } else {
             const errorText = await result.text();
             throw new Error(`Authentication failed: ${errorText}`);

--- a/examples/server/server/static/auth-advanced.js
+++ b/examples/server/server/static/auth-advanced.js
@@ -206,7 +206,7 @@ export async function advancedRegister() {
 
             showStatus('advanced', `Advanced registration successful! Algorithm: ${data.algo || 'Unknown'}`, 'success');
 
-            showRegistrationResultModal(credentialJson, data.relyingParty || null);
+            await showRegistrationResultModal(credentialJson, data.relyingParty || null);
 
             setTimeout(loadSavedCredentials, 1000);
         } else {

--- a/examples/server/server/static/auth-debug.js
+++ b/examples/server/server/static/auth-debug.js
@@ -10,7 +10,7 @@ export function printRegistrationDebug(credential, createOptions, serverResponse
     const residentKey = clientExtensions.credProps?.rk || serverData.actualResidentKey || false;
     console.log('Resident key:', residentKey);
 
-    const attestationFormat = serverData.attestationFormat || 'none';
+    const attestationFormat = serverData.attestationFormat || 'direct';
     const attestationRetrieved = attestationFormat !== 'none';
     console.log('Attestation (retrieve or not, plus the format):', `${attestationRetrieved}, ${attestationFormat}`);
 

--- a/examples/server/server/static/auth-simple.js
+++ b/examples/server/server/static/auth-simple.js
@@ -9,6 +9,14 @@ import { showStatus, hideStatus, showProgress, hideProgress } from './status.js'
 import { loadSavedCredentials } from './credential-display.js';
 import { printRegistrationDebug, printAuthenticationDebug } from './auth-debug.js';
 import { state } from './state.js';
+import { randomizeSimpleUsername } from './username.js';
+
+function maybeRandomizeSimpleUsername() {
+    const input = document.getElementById('simple-email');
+    if (input && input.value.trim()) {
+        randomizeSimpleUsername();
+    }
+}
 
 export async function simpleRegister() {
     const email = document.getElementById('simple-email').value;
@@ -65,6 +73,8 @@ export async function simpleRegister() {
             printRegistrationDebug(credential, createOptions, data);
 
             showStatus('simple', `Registration successful! Algorithm: ${data.algo || 'Unknown'}`, 'success');
+
+            maybeRandomizeSimpleUsername();
 
             setTimeout(loadSavedCredentials, 1000);
         } else {
@@ -138,6 +148,8 @@ export async function simpleAuthenticate() {
             printAuthenticationDebug(assertion, getOptions, data);
 
             showStatus('simple', 'Authentication successful! You have been verified.', 'success');
+
+            maybeRandomizeSimpleUsername();
         } else {
             const errorText = await result.text();
             throw new Error(`Authentication failed: ${errorText}`);

--- a/examples/server/server/static/credential-display.js
+++ b/examples/server/server/static/credential-display.js
@@ -1315,7 +1315,7 @@ export async function showRegistrationResultModal(credentialJson, relyingPartyIn
         || attestationHasCertificates;
 
     const hasAuthenticatorData = Boolean(registrationDetailState.authenticatorData);
-    const authenticatorButton = hasAuthenticatorData
+    const authenticatorButtonMarkup = hasAuthenticatorData
         ? '<button type="button" class="btn btn-small btn-secondary registration-authenticator-data-button">Authenticator Data</button>'
         : '';
     const shouldShowAuthenticatorError = !hasAuthenticatorData && authenticatorDataValue && authenticatorDecodeError;
@@ -1344,8 +1344,8 @@ export async function showRegistrationResultModal(credentialJson, relyingPartyIn
             certificateMessageHtml = '<div style="font-style: italic; color: #6c757d; margin-top: 0.75rem;">No attestation certificates available.</div>';
         }
 
-        if (authenticatorButton) {
-            buttonRowSegments.push(authenticatorButton);
+        if (authenticatorButtonMarkup) {
+            buttonRowSegments.push(authenticatorButtonMarkup);
         }
 
         const buttonRowHtml = buttonRowSegments.length
@@ -1365,12 +1365,12 @@ export async function showRegistrationResultModal(credentialJson, relyingPartyIn
                 ${authenticatorMessageHtml}
             </section>
         `;
-    } else if (authenticatorButton || shouldShowAuthenticatorError) {
-        const buttonRowHtml = authenticatorButton
-            ? `<div class="registration-detail-button-row registration-detail-button-row--solo">${authenticatorButton}</div>`
+    } else if (authenticatorButtonMarkup || shouldShowAuthenticatorError) {
+        const buttonRowHtml = authenticatorButtonMarkup
+            ? `<div class="registration-detail-button-row registration-detail-button-row--solo">${authenticatorButtonMarkup}</div>`
             : '';
         const authenticatorMessageHtml = shouldShowAuthenticatorError
-            ? `<div style="color: #dc3545; font-size: 0.9rem; ${authenticatorButton ? 'margin-top: 0.75rem;' : ''}">${escapeHtml(authenticatorDecodeError)}</div>`
+            ? `<div style="color: #dc3545; font-size: 0.9rem; ${authenticatorButtonMarkup ? 'margin-top: 0.75rem;' : ''}">${escapeHtml(authenticatorDecodeError)}</div>`
             : '';
 
         attestationSectionHtml = `
@@ -1398,9 +1398,9 @@ export async function showRegistrationResultModal(credentialJson, relyingPartyIn
         });
     });
 
-    const authenticatorButton = modalBody.querySelector('.registration-authenticator-data-button');
-    if (authenticatorButton) {
-        authenticatorButton.addEventListener('click', event => {
+    const authenticatorButtonEl = modalBody.querySelector('.registration-authenticator-data-button');
+    if (authenticatorButtonEl) {
+        authenticatorButtonEl.addEventListener('click', event => {
             event.preventDefault();
             openAuthenticatorDataDetail();
         });

--- a/examples/server/server/static/credential-display.js
+++ b/examples/server/server/static/credential-display.js
@@ -1310,23 +1310,35 @@ export async function showRegistrationResultModal(credentialJson, relyingPartyIn
             attestationContent = '<div style="font-style: italic; color: #6c757d; margin-bottom: 0.75rem;">No attestationObject was provided.</div>';
         }
 
-        const certificateButtonsHtml = registrationDetailState.attestationCertificates.length
-            ? `<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem;">${registrationDetailState.attestationCertificates.map((_, index) => `<button type="button" class="btn btn-small registration-attestation-cert-button" data-cert-index="${index}">Certificate ${index + 1}</button>`).join('')}</div>`
-            : '<div style="font-style: italic; color: #6c757d; margin-top: 0.75rem;">No attestation certificates available.</div>';
+        const buttonRowSegments = [];
+        let certificateMessageHtml = '';
+        let authenticatorMessageHtml = '';
 
-        let authenticatorButtonHtml = '';
-        if (registrationDetailState.authenticatorData) {
-            authenticatorButtonHtml = '<div style="margin-top: 1rem;"><button type="button" class="btn btn-small btn-secondary registration-authenticator-data-button">authenticatorData</button></div>';
-        } else if (authenticatorDataValue && authenticatorDecodeError) {
-            authenticatorButtonHtml = `<div style="color: #dc3545; font-size: 0.9rem; margin-top: 0.75rem;">${escapeHtml(authenticatorDecodeError)}</div>`;
+        if (registrationDetailState.attestationCertificates.length) {
+            registrationDetailState.attestationCertificates.forEach((_, index) => {
+                buttonRowSegments.push(`<button type="button" class="btn btn-small registration-attestation-cert-button" data-cert-index="${index}">Attestation Certificate ${index + 1}</button>`);
+            });
+        } else {
+            certificateMessageHtml = '<div style="font-style: italic; color: #6c757d; margin-top: 0.75rem;">No attestation certificates available.</div>';
         }
+
+        if (registrationDetailState.authenticatorData) {
+            buttonRowSegments.push('<button type="button" class="btn btn-small btn-secondary registration-authenticator-data-button">Authenticator Data</button>');
+        } else if (authenticatorDataValue && authenticatorDecodeError) {
+            authenticatorMessageHtml = `<div style="color: #dc3545; font-size: 0.9rem; margin-top: 0.75rem;">${escapeHtml(authenticatorDecodeError)}</div>`;
+        }
+
+        const buttonRowHtml = buttonRowSegments.length
+            ? `<div class="registration-detail-button-row">${buttonRowSegments.join('')}</div>`
+            : '';
 
         attestationSectionHtml = `
             <section style="margin-bottom: 1.5rem;">
-                <h3 style="color: #0072CE; margin-bottom: 0.75rem;">Attestation Object &amp; Authenticator Data</h3>
+                <h3 style="color: #0072CE; margin-bottom: 0.75rem;">Attestation and Authenticator Data</h3>
                 ${attestationContent}
-                ${certificateButtonsHtml}
-                ${authenticatorButtonHtml}
+                ${buttonRowHtml}
+                ${certificateMessageHtml}
+                ${authenticatorMessageHtml}
             </section>
         `;
     }

--- a/examples/server/server/static/forms.js
+++ b/examples/server/server/static/forms.js
@@ -10,7 +10,7 @@ import {
 import { getCredentialIdHex, getStoredCredentialAttachment } from './credential-utils.js';
 import { showStatus } from './status.js';
 import { updateJsonEditor } from './json-editor.js';
-import { renderFakeExcludeCredentialList } from './exclude-credentials.js';
+import { renderFakeExcludeCredentialList, renderFakeAllowCredentialList } from './exclude-credentials.js';
 
 export function changeBinaryFormat() {
     const newFormat = getCurrentBinaryFormat();
@@ -35,6 +35,7 @@ export function changeBinaryFormat() {
     updateJsonEditor();
     window.currentBinaryFormat = newFormat;
     renderFakeExcludeCredentialList();
+    renderFakeAllowCredentialList();
 }
 
 function credentialSupportsLargeBlob(cred) {

--- a/examples/server/server/static/json-editor.js
+++ b/examples/server/server/static/json-editor.js
@@ -64,11 +64,11 @@ export function getCredentialCreationOptions() {
         pubKeyCredParams: [],
         timeout: parseInt(document.getElementById('timeout-reg')?.value) || 90000,
         authenticatorSelection: {},
-        attestation: document.getElementById('attestation')?.value || 'none',
+        attestation: document.getElementById('attestation')?.value || 'direct',
         extensions: {}
     };
 
-    const authenticatorAttachment = document.getElementById('authenticator-attachment')?.value || 'unspecified';
+    const authenticatorAttachment = document.getElementById('authenticator-attachment')?.value || 'cross-platform';
     if (authenticatorAttachment && authenticatorAttachment !== 'unspecified') {
         publicKey.authenticatorSelection.authenticatorAttachment = authenticatorAttachment;
     }
@@ -458,7 +458,7 @@ export function updateRegistrationFormFromJson(publicKey) {
     }
 
     if (Object.prototype.hasOwnProperty.call(publicKey, 'attestation')) {
-        document.getElementById('attestation').value = publicKey.attestation || 'none';
+        document.getElementById('attestation').value = publicKey.attestation || 'direct';
     }
 
     if (publicKey.pubKeyCredParams && Array.isArray(publicKey.pubKeyCredParams)) {
@@ -524,9 +524,12 @@ export function updateRegistrationFormFromJson(publicKey) {
         const attachmentElement = document.getElementById('authenticator-attachment');
         if (attachmentElement) {
             const attachmentValue = publicKey.authenticatorSelection.authenticatorAttachment;
-            const normalizedAttachment = attachmentValue === 'platform' || attachmentValue === 'cross-platform'
-                ? attachmentValue
-                : 'unspecified';
+            let normalizedAttachment = 'cross-platform';
+            if (attachmentValue === 'platform' || attachmentValue === 'cross-platform') {
+                normalizedAttachment = attachmentValue;
+            } else if (attachmentValue === 'unspecified') {
+                normalizedAttachment = 'unspecified';
+            }
             attachmentElement.value = normalizedAttachment;
         }
         const residentKeyElement = document.getElementById('resident-key');
@@ -544,7 +547,7 @@ export function updateRegistrationFormFromJson(publicKey) {
     } else {
         const attachmentElement = document.getElementById('authenticator-attachment');
         if (attachmentElement) {
-            attachmentElement.value = 'unspecified';
+            attachmentElement.value = 'cross-platform';
         }
     }
 
@@ -778,7 +781,7 @@ export function getAdvancedCreateOptions() {
         attestation: document.getElementById('attestation').value,
         userVerification: document.getElementById('user-verification-reg').value,
         residentKey: document.getElementById('resident-key').value,
-        authenticatorAttachment: document.getElementById('authenticator-attachment').value || 'unspecified',
+        authenticatorAttachment: document.getElementById('authenticator-attachment').value || 'cross-platform',
 
         excludeCredentials: document.getElementById('exclude-credentials').checked,
         fakeCredLength: parseInt(document.getElementById('fake-cred-length-reg').value) || 0,
@@ -939,7 +942,7 @@ export function applyJsonChanges() {
             if (parsed.username) document.getElementById('user-name').value = parsed.username;
             if (parsed.displayName) document.getElementById('user-display-name').value = parsed.displayName;
             if (Object.prototype.hasOwnProperty.call(parsed, 'attestation')) {
-                document.getElementById('attestation').value = parsed.attestation || 'none';
+                document.getElementById('attestation').value = parsed.attestation || 'direct';
             }
             if (Object.prototype.hasOwnProperty.call(parsed, 'userVerification')) {
                 document.getElementById('user-verification-reg').value = parsed.userVerification || 'preferred';
@@ -949,9 +952,9 @@ export function applyJsonChanges() {
                 const attachmentSelect = document.getElementById('authenticator-attachment');
                 if (attachmentSelect) {
                     const rawValue = parsed.authenticatorAttachment;
-                    const normalized = rawValue === 'platform' || rawValue === 'cross-platform'
+                    const normalized = rawValue === 'platform' || rawValue === 'cross-platform' || rawValue === 'unspecified'
                         ? rawValue
-                        : 'unspecified';
+                        : 'cross-platform';
                     attachmentSelect.value = normalized;
                 }
             }

--- a/examples/server/server/static/mds/table.css
+++ b/examples/server/server/static/mds/table.css
@@ -64,7 +64,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .mds-header-text {
@@ -248,14 +248,16 @@
 
 .mds-tag-group {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
 }
 
 .mds-tag {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     padding: 0.16rem 0.5rem;
     border-radius: 999px;
     background: rgba(0, 114, 206, 0.12);
@@ -263,7 +265,10 @@
     font-size: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.01em;
-    white-space: nowrap;
+    white-space: normal;
+    text-align: center;
+    width: 100%;
+    overflow-wrap: anywhere;
 }
 
 .mds-tag--neutral {

--- a/examples/server/server/static/mds/table.css
+++ b/examples/server/server/static/mds/table.css
@@ -202,15 +202,15 @@
 }
 
 .mds-table tbody td {
-    padding: 0.45rem 0.85rem;
+    padding: 0.3rem 0.7rem;
     border-top: 1px solid rgba(0, 114, 206, 0.08);
     vertical-align: middle;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     color: var(--text-color);
     background: rgba(255, 255, 255, 0.98);
     text-align: center;
     white-space: normal;
-    line-height: 1.35;
+    line-height: 1.25;
 }
 
 .mds-table thead th,
@@ -250,7 +250,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.2rem;
     width: 100%;
 }
 
@@ -258,11 +258,11 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.16rem 0.5rem;
+    padding: 0.12rem 0.45rem;
     border-radius: 999px;
     background: rgba(0, 114, 206, 0.12);
     color: var(--primary-dark);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     font-weight: 600;
     letter-spacing: 0.01em;
     white-space: normal;
@@ -277,8 +277,8 @@
 }
 
 .mds-icon-wrapper {
-    width: 60px;
-    height: 60px;
+    width: 52px;
+    height: 52px;
     border-radius: 12px;
     background: rgba(243, 247, 251, 0.95);
     display: flex;
@@ -289,8 +289,8 @@
 }
 
 .mds-icon-wrapper img {
-    max-width: 50px;
-    max-height: 50px;
+    max-width: 44px;
+    max-height: 44px;
     object-fit: contain;
     border-radius: 10px;
 }

--- a/examples/server/server/static/resets.js
+++ b/examples/server/server/static/resets.js
@@ -1,18 +1,14 @@
 import {
-    randomizeUserId,
     randomizeChallenge,
     validatePrfInputs,
     updateAuthenticationExtensionAvailability
 } from './forms.js';
-import { generateRandom10DigitUsername } from './username.js';
+import { randomizeUserIdentity } from './username.js';
 import { updateJsonEditor } from './json-editor.js';
 import { clearFakeExcludeCredentials } from './exclude-credentials.js';
 
 export function resetRegistrationForm() {
-    randomizeUserId();
-    const randomUsername = generateRandom10DigitUsername();
-    document.getElementById('user-name').value = randomUsername;
-    document.getElementById('user-display-name').value = randomUsername;
+    randomizeUserIdentity();
 
     document.getElementById('resident-key').value = 'discouraged';
     document.getElementById('user-verification-reg').value = 'preferred';

--- a/examples/server/server/static/resets.js
+++ b/examples/server/server/static/resets.js
@@ -5,7 +5,7 @@ import {
 } from './forms.js';
 import { randomizeUserIdentity } from './username.js';
 import { updateJsonEditor } from './json-editor.js';
-import { clearFakeExcludeCredentials } from './exclude-credentials.js';
+import { clearFakeExcludeCredentials, clearFakeAllowCredentials } from './exclude-credentials.js';
 
 export function resetRegistrationForm() {
     randomizeUserIdentity();
@@ -53,7 +53,7 @@ export function resetRegistrationForm() {
 export function resetAuthenticationForm() {
     document.getElementById('user-verification-auth').value = 'preferred';
     document.getElementById('allow-credentials').value = 'all';
-    document.getElementById('fake-cred-length-auth').value = '256';
+    document.getElementById('fake-cred-length-auth').value = '128';
 
     randomizeChallenge('auth');
     document.getElementById('timeout-auth').value = '90000';
@@ -67,6 +67,8 @@ export function resetAuthenticationForm() {
     document.getElementById('prf-eval-first-auth').value = '';
     document.getElementById('prf-eval-second-auth').value = '';
     document.getElementById('prf-eval-second-auth').disabled = true;
+
+    clearFakeAllowCredentials();
 
     validatePrfInputs('reg');
     validatePrfInputs('auth');

--- a/examples/server/server/static/resets.js
+++ b/examples/server/server/static/resets.js
@@ -10,9 +10,10 @@ import { clearFakeExcludeCredentials } from './exclude-credentials.js';
 export function resetRegistrationForm() {
     randomizeUserIdentity();
 
+    document.getElementById('authenticator-attachment').value = 'cross-platform';
     document.getElementById('resident-key').value = 'discouraged';
     document.getElementById('user-verification-reg').value = 'preferred';
-    document.getElementById('attestation').value = 'none';
+    document.getElementById('attestation').value = 'direct';
     document.getElementById('exclude-credentials').checked = true;
     document.getElementById('fake-cred-length-reg').value = '128';
 

--- a/examples/server/server/static/resets.js
+++ b/examples/server/server/static/resets.js
@@ -53,7 +53,7 @@ export function resetRegistrationForm() {
 export function resetAuthenticationForm() {
     document.getElementById('user-verification-auth').value = 'preferred';
     document.getElementById('allow-credentials').value = 'all';
-    document.getElementById('fake-cred-length-auth').value = '128';
+    document.getElementById('fake-cred-length-auth').value = '256';
 
     randomizeChallenge('auth');
     document.getElementById('timeout-auth').value = '90000';

--- a/examples/server/server/static/script.js
+++ b/examples/server/server/static/script.js
@@ -20,7 +20,6 @@ import {
 import {
     changeBinaryFormat,
     updateFieldLabels,
-    randomizeUserId,
     randomizeChallenge,
     randomizePrfEval,
     randomizeLargeBlobWrite,
@@ -36,10 +35,7 @@ import {
     resetRegistrationForm,
     resetAuthenticationForm
 } from './resets.js';
-import {
-    randomizeUsername,
-    generateRandom10DigitUsername
-} from './username.js';
+import { randomizeUserIdentity } from './username.js';
 import {
     simpleRegister,
     simpleAuthenticate
@@ -69,7 +65,9 @@ import {
     navigateToMdsAuthenticator,
     closeCredentialModal,
     closeRegistrationResultModal,
-    deleteCredential
+    closeRegistrationDetailModal,
+    deleteCredential,
+    clearAllCredentials
 } from './credential-display.js';
 import { handleJsonEditorKeydown } from './json-editor-utils.js';
 import {
@@ -90,13 +88,12 @@ window.toggleSection = toggleSection;
 window.showInfoPopup = showInfoPopup;
 window.hideInfoPopup = hideInfoPopup;
 window.toggleLanguage = toggleLanguage;
-window.randomizeUserId = randomizeUserId;
 window.randomizeChallenge = randomizeChallenge;
 window.randomizePrfEval = randomizePrfEval;
 window.randomizeLargeBlobWrite = randomizeLargeBlobWrite;
 window.resetRegistrationForm = resetRegistrationForm;
 window.resetAuthenticationForm = resetAuthenticationForm;
-window.randomizeUsername = randomizeUsername;
+window.randomizeUserIdentity = randomizeUserIdentity;
 window.simpleRegister = simpleRegister;
 window.simpleAuthenticate = simpleAuthenticate;
 window.advancedRegister = advancedRegister;
@@ -111,7 +108,9 @@ window.showCredentialDetails = showCredentialDetails;
 window.navigateToMdsAuthenticator = navigateToMdsAuthenticator;
 window.closeCredentialModal = closeCredentialModal;
 window.closeRegistrationResultModal = closeRegistrationResultModal;
+window.closeRegistrationDetailModal = closeRegistrationDetailModal;
 window.deleteCredential = deleteCredential;
+window.clearAllCredentials = clearAllCredentials;
 window.editCreateOptions = editCreateOptions;
 window.editAssertOptions = editAssertOptions;
 window.applyJsonChanges = applyJsonChanges;
@@ -133,12 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     setTimeout(() => {
-        randomizeUserId();
-        const randomUsername = generateRandom10DigitUsername();
-        const userName = document.getElementById('user-name');
-        const displayName = document.getElementById('user-display-name');
-        if (userName) userName.value = randomUsername;
-        if (displayName) displayName.value = randomUsername;
+        randomizeUserIdentity();
         randomizeChallenge('reg');
         randomizeChallenge('auth');
         randomizeLargeBlobWrite();

--- a/examples/server/server/static/script.js
+++ b/examples/server/server/static/script.js
@@ -35,7 +35,7 @@ import {
     resetRegistrationForm,
     resetAuthenticationForm
 } from './resets.js';
-import { randomizeUserIdentity } from './username.js';
+import { randomizeUserIdentity, randomizeSimpleUsername } from './username.js';
 import {
     simpleRegister,
     simpleAuthenticate
@@ -73,7 +73,10 @@ import { handleJsonEditorKeydown } from './json-editor-utils.js';
 import {
     createFakeExcludeCredential,
     removeFakeExcludeCredential,
-    renderFakeExcludeCredentialList
+    renderFakeExcludeCredentialList,
+    createFakeAllowCredential,
+    removeFakeAllowCredential,
+    renderFakeAllowCredentialList
 } from './exclude-credentials.js';
 
 window.create = create;
@@ -94,6 +97,7 @@ window.randomizeLargeBlobWrite = randomizeLargeBlobWrite;
 window.resetRegistrationForm = resetRegistrationForm;
 window.resetAuthenticationForm = resetAuthenticationForm;
 window.randomizeUserIdentity = randomizeUserIdentity;
+window.randomizeSimpleUsername = randomizeSimpleUsername;
 window.simpleRegister = simpleRegister;
 window.simpleAuthenticate = simpleAuthenticate;
 window.advancedRegister = advancedRegister;
@@ -154,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
         loadSavedCredentials();
         updateJsonEditor();
         renderFakeExcludeCredentialList();
+        renderFakeAllowCredentialList();
         updateAuthenticationExtensionAvailability();
     }, 100);
 
@@ -242,6 +247,35 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 event.preventDefault();
                 const removed = removeFakeExcludeCredential(button.dataset.fakeCredentialIndex);
+                if (removed) {
+                    updateJsonEditor();
+                }
+            });
+        }
+
+        const fakeAllowButton = document.getElementById('fake-cred-generate-auth');
+        if (fakeAllowButton) {
+            fakeAllowButton.addEventListener('click', () => {
+                const lengthInput = document.getElementById('fake-cred-length-auth');
+                const lengthValue = lengthInput ? lengthInput.value : '';
+                const created = createFakeAllowCredential(lengthValue);
+                if (created) {
+                    updateJsonEditor();
+                }
+            });
+        }
+
+        const fakeAllowList = document.getElementById('fake-cred-auth-generated-list');
+        if (fakeAllowList) {
+            fakeAllowList.addEventListener('click', event => {
+                const button = event.target instanceof HTMLElement
+                    ? event.target.closest('button[data-fake-credential-index]')
+                    : null;
+                if (!button) {
+                    return;
+                }
+                event.preventDefault();
+                const removed = removeFakeAllowCredential(button.dataset.fakeCredentialIndex);
                 if (removed) {
                     updateJsonEditor();
                 }

--- a/examples/server/server/static/state.js
+++ b/examples/server/server/static/state.js
@@ -5,5 +5,6 @@ export const state = {
     currentJsonData: null,
     lastFakeCredLength: 0,
     generatedExcludeCredentials: [],
+    generatedAllowCredentials: [],
     utf8Decoder: typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : null,
 };

--- a/examples/server/server/static/styles/base.css
+++ b/examples/server/server/static/styles/base.css
@@ -174,6 +174,18 @@ body.modal-open {
     color: var(--muted-text);
 }
 
+.form-group .form-label-inline {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.form-group .form-label-inline label {
+    margin: 0;
+}
+
 .form-group .checkbox-label,
 .checkbox-item .checkbox-label {
     display: inline-flex;

--- a/examples/server/server/static/styles/layout.css
+++ b/examples/server/server/static/styles/layout.css
@@ -92,6 +92,23 @@
     height: 1.5rem; /* Fixed height for alignment */
 }
 
+.section-title-with-action {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.section-title-with-action h3 {
+    margin-bottom: 0;
+}
+
+.section-title-with-action .btn {
+    flex-shrink: 0;
+}
+
 .form-section-title {
     display: block;
     margin-bottom: 0.5rem;

--- a/examples/server/server/static/styles/layout.css
+++ b/examples/server/server/static/styles/layout.css
@@ -92,21 +92,27 @@
     height: 1.5rem; /* Fixed height for alignment */
 }
 
+
 .credentials-column .credentials-panel-title {
-    margin-bottom: 0.75rem;
+    margin-bottom: 0;
     color: var(--primary-dark);
     font-size: 1.1rem;
     height: auto;
 }
 
-.credentials-toolbar {
+.credentials-panel-header {
     display: flex;
-    justify-content: flex-end;
-    padding: 0 1rem;
-    margin-bottom: 0.5rem;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
 }
 
-.credentials-toolbar .btn {
+.credentials-panel-header .credentials-panel-title {
+    margin-bottom: 0;
+}
+
+.credentials-panel-header .btn {
     flex-shrink: 0;
 }
 

--- a/examples/server/server/static/styles/layout.css
+++ b/examples/server/server/static/styles/layout.css
@@ -92,6 +92,24 @@
     height: 1.5rem; /* Fixed height for alignment */
 }
 
+.credentials-column .credentials-panel-title {
+    margin-bottom: 0.75rem;
+    color: var(--primary-dark);
+    font-size: 1.1rem;
+    height: auto;
+}
+
+.credentials-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.credentials-toolbar .btn {
+    flex-shrink: 0;
+}
+
 .section-title-with-action {
     display: flex;
     justify-content: space-between;

--- a/examples/server/server/static/styles/modals.css
+++ b/examples/server/server/static/styles/modals.css
@@ -32,6 +32,13 @@
     box-shadow: var(--shadow-hover);
 }
 
+.modal-content.modal-content-large {
+    width: 95vw;
+    max-width: 95vw;
+    height: 95vh;
+    max-height: 95vh;
+}
+
 .modal-header {
     display: flex;
     justify-content: space-between;
@@ -98,6 +105,13 @@
         height: 85vh;
         max-height: 85vh;
         padding: 1.5rem;
+    }
+
+    .modal-content.modal-content-large {
+        width: 95vw;
+        max-width: 95vw;
+        height: 95vh;
+        max-height: 95vh;
     }
 }
 
@@ -262,6 +276,14 @@
     outline: none;
     border-color: rgba(0, 114, 206, 0.25);
     box-shadow: none;
+}
+
+.registration-detail-button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    align-items: center;
 }
 
 .modal-pre {

--- a/examples/server/server/static/styles/modals.css
+++ b/examples/server/server/static/styles/modals.css
@@ -39,6 +39,10 @@
     max-height: 95vh;
 }
 
+#registrationDetailModal {
+    z-index: 1300;
+}
+
 .modal-header {
     display: flex;
     justify-content: space-between;
@@ -142,6 +146,17 @@
     word-break: break-word;
     overflow-wrap: anywhere;
     white-space: pre-wrap;
+}
+
+.credential-registration-copy {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid rgba(0, 114, 206, 0.15);
+}
+
+.credential-registration-copy > h4 {
+    color: #0072CE;
+    margin-bottom: 0.75rem;
 }
 
 .credential-aaguid-row {

--- a/examples/server/server/static/styles/modals.css
+++ b/examples/server/server/static/styles/modals.css
@@ -286,6 +286,10 @@
     align-items: center;
 }
 
+.registration-detail-button-row--solo {
+    margin-top: 0;
+}
+
 .modal-pre {
     background: rgba(0, 114, 206, 0.08);
     padding: 0.85rem;

--- a/examples/server/server/static/username.js
+++ b/examples/server/server/static/username.js
@@ -27,3 +27,10 @@ export function randomizeUserIdentity() {
     randomizeUserId();
     randomizeUsername();
 }
+
+export function randomizeSimpleUsername() {
+    const simpleInput = document.getElementById('simple-email');
+    if (simpleInput) {
+        simpleInput.value = generateRandom10DigitUsername();
+    }
+}

--- a/examples/server/server/static/username.js
+++ b/examples/server/server/static/username.js
@@ -1,4 +1,5 @@
 import { updateJsonEditor } from './json-editor.js';
+import { randomizeUserId } from './forms.js';
 
 export function generateRandom10DigitUsername() {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -20,4 +21,9 @@ export function randomizeUsername() {
         displayName.value = randomUsername;
     }
     updateJsonEditor();
+}
+
+export function randomizeUserIdentity() {
+    randomizeUserId();
+    randomizeUsername();
 }

--- a/examples/server/server/templates/index/modals/credential-details.html
+++ b/examples/server/server/templates/index/modals/credential-details.html
@@ -1,6 +1,6 @@
     <!-- Credential Details Modal -->
     <div id="credentialModal" class="modal">
-        <div class="modal-content">
+        <div class="modal-content modal-content-large">
             <div class="modal-header">
                 <h2 class="modal-title">Credential Details</h2>
                 <button class="modal-close" onclick="closeCredentialModal()">&times;</button>

--- a/examples/server/server/templates/index/modals/registration-result.html
+++ b/examples/server/server/templates/index/modals/registration-result.html
@@ -10,3 +10,15 @@
             </div>
         </div>
     </div>
+
+    <div id="registrationDetailModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title" id="registrationDetailModalTitle">Detail</h2>
+                <button class="modal-close" onclick="closeRegistrationDetailModal()">&times;</button>
+            </div>
+            <div class="modal-body" id="registrationDetailModalBody">
+                <!-- Populated dynamically when viewing registration data details -->
+            </div>
+        </div>
+    </div>

--- a/examples/server/server/templates/index/modals/registration-result.html
+++ b/examples/server/server/templates/index/modals/registration-result.html
@@ -12,7 +12,7 @@
     </div>
 
     <div id="registrationDetailModal" class="modal">
-        <div class="modal-content">
+        <div class="modal-content modal-content-large">
             <div class="modal-header">
                 <h2 class="modal-title" id="registrationDetailModalTitle">Detail</h2>
                 <button class="modal-close" onclick="closeRegistrationDetailModal()">&times;</button>

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -619,7 +619,11 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <input type="number" id="fake-cred-length-auth" class="form-control" value="256" min="1">
+                                        <div class="input-with-button">
+                                            <input type="number" id="fake-cred-length-auth" class="form-control" value="128" min="1">
+                                            <button type="button" id="fake-cred-generate-auth" class="btn btn-small add-icon" title="Generate fake credential ID" aria-label="Generate fake credential ID"></button>
+                                        </div>
+                                        <div id="fake-cred-auth-generated-list" class="fake-credential-list" aria-live="polite"></div>
                                     </div>
                                 </div>
                             </div>
@@ -855,11 +859,11 @@
                                         <option value="js">js</option>
                                     </select>
                                 </div>
-                                <h3 class="credentials-panel-title">Saved Credentials</h3>
+                                <div class="credentials-panel-header">
+                                    <h3 class="credentials-panel-title">Saved Credentials</h3>
+                                    <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
+                                </div>
                                 <div class="credentials-panel">
-                                    <div class="credentials-toolbar">
-                                        <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
-                                    </div>
                                     <div id="credentials-list">
                                         <p style="color: #6c757d;">No credentials registered yet.</p>
                                     </div>

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -57,18 +57,18 @@
                                                 <div class="info-popup">
                                                     <div class="language-toggle" onclick="toggleLanguage(this)">ENG</div>
                                                     <div class="text-en active">
-                                                        Select whether an authenticator integrated into the client platform ("platform") or an external device ("cross-platform") should be used. If unspecified (default), either kind of authenticator is allowed.
+                                                        Select whether an authenticator integrated into the client platform ("platform") or an external device ("cross-platform") should be used. If unspecified, either kind of authenticator is allowed. By default, a cross-platform authenticator is requested.
                                                     </div>
                                                     <div class="text-zh hidden">
-                                                        选择是否使用集成在客户端平台中的认证器（“platform”）或外部设备（“cross-platform”）。如果未指定（默认），允许使用任一类型的认证器。
+                                                        选择是否使用集成在客户端平台中的认证器（“platform”）或外部设备（“cross-platform”）。如果未指定，允许使用任一类型的认证器。默认情况下，将请求 cross-platform 认证器。
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
                                         <select id="authenticator-attachment" class="form-control">
-                                            <option value="unspecified">Unspecified (default)</option>
+                                            <option value="cross-platform">Cross-Platform (default)</option>
                                             <option value="platform">Platform</option>
-                                            <option value="cross-platform">Cross-Platform</option>
+                                            <option value="unspecified">Unspecified</option>
                                         </select>
                                     </div>
                                     <div class="form-group">
@@ -125,19 +125,19 @@
                                                     <div class="language-toggle" onclick="toggleLanguage(this)">ENG</div>
                                                     <div class="text-en active">
                                                         Select whether the Relying Party (RP) requires authenticator attestation. Attestation is a way to prove what kind of authenticator is used.<br><br>
-                                                        If "none", no authenticator attestation will be returned. If "indirect", some kind of attestation will be returned if possible, but it may be anonymized by an attestation proxy. If "direct", the authenticator's original attestation will be returned, if any. If "enterprise", the authenticator is requested to produce an individually identifying attestation. By default, "none" is used.
+                                                        If "none", no authenticator attestation will be returned. If "indirect", some kind of attestation will be returned if possible, but it may be anonymized by an attestation proxy. If "direct", the authenticator's original attestation will be returned, if any. If "enterprise", the authenticator is requested to produce an individually identifying attestation. By default, "direct" is used.
                                                     </div>
                                                     <div class="text-zh hidden">
                                                         选择依赖方（RP）是否需要认证器证明。证明是一种证明使用何种认证器的方式。<br><br>
-                                                        如果选择"none"，将不返回认证器证明。如果选择"indirect"，在可能的情况下会返回某种证明，但可能被证明代理匿名化。如果选择"direct"，将返回认证器的原始证明（如果有）。如果选择"enterprise"，请求认证器产生个别标识证明。默认情况下，使用"none"。
+                                                        如果选择"none"，将不返回认证器证明。如果选择"indirect"，在可能的情况下会返回某种证明，但可能被证明代理匿名化。如果选择"direct"，将返回认证器的原始证明（如果有）。如果选择"enterprise"，请求认证器产生个别标识证明。默认情况下，使用"direct"。
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
                                         <select id="attestation" class="form-control">
-                                            <option value="none">None (default)</option>
+                                            <option value="direct">Direct (default)</option>
+                                            <option value="none">None</option>
                                             <option value="indirect">Indirect</option>
-                                            <option value="direct">Direct</option>
                                             <option value="enterprise">Enterprise</option>
                                         </select>
                                     </div>
@@ -855,11 +855,11 @@
                                         <option value="js">js</option>
                                     </select>
                                 </div>
-                                <div class="section-title-with-action">
-                                    <h3>Saved Credentials</h3>
-                                    <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
-                                </div>
+                                <h3 class="credentials-panel-title">Saved Credentials</h3>
                                 <div class="credentials-panel">
+                                    <div class="credentials-toolbar">
+                                        <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
+                                    </div>
                                     <div id="credentials-list">
                                         <p style="color: #6c757d;">No credentials registered yet.</p>
                                     </div>

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -855,8 +855,8 @@
                                         <option value="js">js</option>
                                     </select>
                                 </div>
-                                <h3>Saved Credentials</h3>
-                                <div class="form-group" style="display: flex; justify-content: flex-end; margin-bottom: 0.5rem;">
+                                <div class="section-title-with-action">
+                                    <h3>Saved Credentials</h3>
                                     <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
                                 </div>
                                 <div class="credentials-panel">

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -28,16 +28,13 @@
                                         <label for="user-id">User ID (hex)</label>
                                         <div class="input-with-button">
                                             <input type="text" id="user-id" class="form-control" placeholder="Auto-generated hex value">
-                                            <button class="btn btn-small refresh-icon" onclick="randomizeUserId()" title="Generate new random User ID"></button>
+                                            <button class="btn btn-small refresh-icon" onclick="randomizeUserIdentity()" title="Generate a new random User ID and username" aria-label="Generate a new random User ID and username"></button>
                                         </div>
                                         <div id="user-id-error" class="error-message">Invalid hex value (1-64 bytes required)</div>
                                     </div>
                                     <div class="form-group">
                                         <label for="user-name">User Name</label>
-                                        <div class="input-with-button">
-                                            <input type="text" id="user-name" class="form-control" placeholder="Enter username">
-                                            <button class="btn btn-small refresh-icon" onclick="randomizeUsername()" title="Generate new random username"></button>
-                                        </div>
+                                        <input type="text" id="user-name" class="form-control" placeholder="Enter username">
                                     </div>
                                     <div class="form-group">
                                         <label for="user-display-name">Display Name</label>
@@ -859,6 +856,9 @@
                                     </select>
                                 </div>
                                 <h3>Saved Credentials</h3>
+                                <div class="form-group" style="display: flex; justify-content: flex-end; margin-bottom: 0.5rem;">
+                                    <button id="clear-credentials" class="btn btn-small btn-danger" onclick="clearAllCredentials()">Clear All</button>
+                                </div>
                                 <div class="credentials-panel">
                                     <div id="credentials-list">
                                         <p style="color: #6c757d;">No credentials registered yet.</p>

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -620,7 +620,7 @@
                                             </div>
                                         </div>
                                         <div class="input-with-button">
-                                            <input type="number" id="fake-cred-length-auth" class="form-control" value="128" min="1">
+                                            <input type="number" id="fake-cred-length-auth" class="form-control" value="256" min="1">
                                             <button type="button" id="fake-cred-generate-auth" class="btn btn-small add-icon" title="Generate fake credential ID" aria-label="Generate fake credential ID"></button>
                                         </div>
                                         <div id="fake-cred-auth-generated-list" class="fake-credential-list" aria-live="polite"></div>

--- a/examples/server/server/templates/index/tabs/simple.html
+++ b/examples/server/server/templates/index/tabs/simple.html
@@ -6,11 +6,11 @@
                     <div class="status" id="simple-status"></div>
 
                     <div class="form-group">
-                        <label for="simple-email">Username</label>
-                        <div class="input-with-button">
-                            <input type="text" id="simple-email" class="form-control" placeholder="Enter username">
+                        <div class="form-label-inline">
+                            <label for="simple-email">Username</label>
                             <button class="btn btn-small refresh-icon" onclick="randomizeSimpleUsername()" title="Generate random username" aria-label="Generate random username"></button>
                         </div>
+                        <input type="text" id="simple-email" class="form-control" placeholder="Enter username">
                     </div>
 
                     <div class="form-group">

--- a/examples/server/server/templates/index/tabs/simple.html
+++ b/examples/server/server/templates/index/tabs/simple.html
@@ -7,7 +7,10 @@
 
                     <div class="form-group">
                         <label for="simple-email">Username</label>
-                        <input type="text" id="simple-email" class="form-control" placeholder="Enter username">
+                        <div class="input-with-button">
+                            <input type="text" id="simple-email" class="form-control" placeholder="Enter username">
+                            <button class="btn btn-small refresh-icon" onclick="randomizeSimpleUsername()" title="Generate random username" aria-label="Generate random username"></button>
+                        </div>
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- replace separate user ID and username randomization buttons with a single control and update the identity reset flow accordingly
- add a "Clear All" action for saved credentials, including the supporting API endpoint and UI state handling
- enhance the registration result modal with decoded attestation object output, per-certificate detail buttons, and an authenticator data viewer using a new detail modal

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d271617afc832c93fb9e22444c3ee7