### PR TITLE
Adjust simple auth defaults and attestation detail display

### DIFF
--- a/examples/server/server/static/credential-display.js
+++ b/examples/server/server/static/credential-display.js
@@ -384,7 +384,14 @@ function buildAttestationSection({
     const attestationStatementHasContent = attestationStatementObject && Object.keys(attestationStatementObject).length > 0;
     const attestationHasCertificates = registrationDetailState.attestationCertificates.length > 0;
 
-    const shouldShowAttestationSection = (attestationFormatNormalized && attestationFormatNormalized !== 'none')
+    const hasAttestationObject = Boolean(attestationObject);
+    const hasAttestationValue = typeof attestationObjectValue === 'string'
+        ? attestationObjectValue.trim() !== ''
+        : false;
+
+    const shouldShowAttestationSection = hasAttestationObject
+        || hasAttestationValue
+        || (attestationFormatNormalized && attestationFormatNormalized !== 'none')
         || attestationStatementHasContent
         || attestationHasCertificates;
 
@@ -906,21 +913,6 @@ function openAttestationCertificateDetail(index) {
         sections.push(`<textarea class="certificate-textarea" readonly spellcheck="false" wrap="soft">${escapeHtml(summary)}</textarea>`);
     } else {
         sections.push('<div style="font-style: italic; color: #6c757d;">No decoded certificate details available.</div>');
-    }
-
-    if (normalised.pem) {
-        sections.push('<h4 style="margin-top: 1rem;">PEM</h4>');
-        sections.push(`<pre class="modal-pre">${escapeHtml(normalised.pem)}</pre>`);
-    }
-
-    if (normalised.raw) {
-        sections.push('<h4 style="margin-top: 1rem;">Raw certificate (hex)</h4>');
-        sections.push(`<pre class="modal-pre">${escapeHtml(normalised.raw)}</pre>`);
-    }
-
-    if (parsed && Object.keys(parsed).length > 0) {
-        sections.push('<h4 style="margin-top: 1rem;">Parsed certificate JSON</h4>');
-        sections.push(`<pre class="modal-pre">${escapeHtml(JSON.stringify(parsed, null, 2))}</pre>`);
     }
 
     openRegistrationDetailModal(`Attestation Certificate ${index + 1}`, sections.join(''));

--- a/examples/server/server/static/resets.js
+++ b/examples/server/server/static/resets.js
@@ -32,7 +32,7 @@ export function resetRegistrationForm() {
     if (document.getElementById('param-mldsa87')) document.getElementById('param-mldsa87').checked = false;
     document.getElementById('hint-client-device').checked = false;
     document.getElementById('hint-hybrid').checked = false;
-    document.getElementById('hint-security-key').checked = true;
+    document.getElementById('hint-security-key').checked = false;
 
     document.getElementById('cred-props').checked = true;
     document.getElementById('min-pin-length').checked = false;
@@ -59,7 +59,7 @@ export function resetAuthenticationForm() {
     document.getElementById('timeout-auth').value = '90000';
     document.getElementById('hint-client-device-auth').checked = false;
     document.getElementById('hint-hybrid-auth').checked = false;
-    document.getElementById('hint-security-key-auth').checked = true;
+    document.getElementById('hint-security-key-auth').checked = false;
 
     document.getElementById('large-blob-auth').value = '';
     document.getElementById('large-blob-write').value = '';

--- a/examples/server/server/static/script.js
+++ b/examples/server/server/static/script.js
@@ -140,6 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
         randomizeChallenge('reg');
         randomizeChallenge('auth');
         randomizeLargeBlobWrite();
+        randomizeSimpleUsername();
         const prfRegFirst = document.getElementById('prf-eval-first-reg');
         const prfRegSecond = document.getElementById('prf-eval-second-reg');
         const prfAuthFirst = document.getElementById('prf-eval-first-auth');

--- a/examples/server/server/templates/index/tabs/advanced.html
+++ b/examples/server/server/templates/index/tabs/advanced.html
@@ -348,7 +348,7 @@
                                             </div>
                                             <div class="checkbox-item">
                                                 <label class="checkbox-label" for="hint-security-key">
-                                                    <input type="checkbox" id="hint-security-key" checked>
+                                                    <input type="checkbox" id="hint-security-key">
                                                     <span>Security-key</span>
                                                 </label>
                                             </div>
@@ -707,7 +707,7 @@
                                             </div>
                                             <div class="checkbox-item">
                                                 <label class="checkbox-label" for="hint-security-key-auth">
-                                                    <input type="checkbox" id="hint-security-key-auth" checked>
+                                                    <input type="checkbox" id="hint-security-key-auth">
                                                     <span>Security-key</span>
                                                 </label>
                                             </div>


### PR DESCRIPTION
## Summary
- start the simple authentication flow with a generated username and leave authenticator hints unselected by default
- ensure the credential details view includes the full attestation section produced for registration, preserving authenticator data access
- simplify attestation certificate detail modals to only show the decoded certificate information

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36d329d48832c9b3fc652ef1e1f79