### PR TITLE
Normalize advanced PQC algorithm selection

### DIFF
--- a/examples/server/server/pqc.py
+++ b/examples/server/server/pqc.py
@@ -1,0 +1,143 @@
+"""Helpers for integrating liboqs-backed ML-DSA algorithms into the demo server."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, Optional, Sequence, Set, Tuple
+
+from .config import app
+
+
+# COSE algorithm identifiers mapped to their liboqs mechanism names.
+PQC_ALGORITHM_ID_TO_NAME: Dict[int, str] = {
+    -50: "ML-DSA-87",
+    -49: "ML-DSA-65",
+    -48: "ML-DSA-44",
+}
+
+_PQC_ALGORITHM_NAME_TO_ID: Dict[str, int] = {
+    name: alg_id for alg_id, name in PQC_ALGORITHM_ID_TO_NAME.items()
+}
+
+
+def _load_enabled_mechanisms() -> Iterable[str]:
+    """Query liboqs for the list of enabled signature mechanisms."""
+
+    try:  # pragma: no cover - exercised in environments with oqs available
+        import oqs  # type: ignore
+    except ImportError:  # pragma: no cover - explicit messaging handled by caller
+        raise
+
+    enabled: Iterable[str]
+    get_enabled: Optional[Callable[[], Sequence[str]]] = getattr(
+        oqs, "get_enabled_sig_mechanisms", None
+    )
+    if callable(get_enabled):
+        enabled = get_enabled()
+    else:  # pragma: no cover - compatibility fallback for older oqs builds
+        algorithms_attr = getattr(getattr(oqs, "Signature", None), "algorithms", None)
+        if algorithms_attr is None:
+            enabled = ()
+        else:
+            enabled = algorithms_attr
+    return [str(name) for name in enabled]
+
+
+def detect_available_pqc_algorithms() -> Tuple[Set[int], Optional[str]]:
+    """Detect ML-DSA algorithms exposed by liboqs' Python bindings."""
+
+    try:
+        mechanism_names = set(_load_enabled_mechanisms())
+    except ImportError:
+        return set(), (
+            "Post-quantum algorithms require the 'oqs' Python bindings (liboqs). "
+            "Install the python-fido2-webauthn-test[pqc] extra and ensure liboqs is present."
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        app.logger.exception("Failed to enumerate oqs signature mechanisms: %%s", exc)
+        return set(), "Unable to enumerate post-quantum algorithms from the oqs bindings."
+
+    available_ids = {
+        alg_id
+        for alg_id, mechanism in PQC_ALGORITHM_ID_TO_NAME.items()
+        if mechanism in mechanism_names
+    }
+
+    if len(available_ids) == len(PQC_ALGORITHM_ID_TO_NAME):
+        return available_ids, None
+
+    missing = [
+        PQC_ALGORITHM_ID_TO_NAME[alg_id]
+        for alg_id in sorted(PQC_ALGORITHM_ID_TO_NAME)
+        if alg_id not in available_ids
+    ]
+    return available_ids, (
+        "The installed 'oqs' bindings do not include support for: "
+        + ", ".join(missing)
+        + ". Rebuild liboqs with ML-DSA enabled or install an updated wheel."
+    )
+
+
+def is_pqc_algorithm(alg_id: int) -> bool:
+    """Return ``True`` if the COSE algorithm corresponds to an ML-DSA option."""
+
+    return alg_id in PQC_ALGORITHM_ID_TO_NAME
+
+
+def describe_algorithm(alg_id: Optional[int]) -> str:
+    """Return a friendly label for the given COSE algorithm identifier."""
+
+    if alg_id is None:
+        return "Unknown"
+    name = PQC_ALGORITHM_ID_TO_NAME.get(alg_id)
+    if name:
+        return f"{name} (PQC)"
+    if alg_id == -8:
+        return "EdDSA"
+    if alg_id == -7:
+        return "ES256 (ECDSA)"
+    if alg_id == -47:
+        return "ES256K (ECDSA)"
+    if alg_id == -35:
+        return "ES384 (ECDSA)"
+    if alg_id == -36:
+        return "ES512 (ECDSA)"
+    if alg_id == -37:
+        return "PS256 (RSA-PSS)"
+    if alg_id == -257:
+        return "RS256 (RSA)"
+    if alg_id == -258:
+        return "RS384 (RSA)"
+    if alg_id == -259:
+        return "RS512 (RSA)"
+    if alg_id == -65535:
+        return "RS1 (RSA)"
+    return f"COSE alg {alg_id}"
+
+
+def log_algorithm_selection(stage: str, alg_id: Optional[int]) -> None:
+    """Log the negotiated algorithm for the registration/authentication flow."""
+
+    label = describe_algorithm(alg_id)
+    if alg_id is None:
+        app.logger.info("No signature algorithm associated with %s stage.", stage)
+    elif is_pqc_algorithm(alg_id):
+        app.logger.info(
+            "Using post-quantum algorithm %s (COSE %d) during %s.",
+            label,
+            alg_id,
+            stage,
+        )
+    else:
+        app.logger.info(
+            "Using classical algorithm %s (COSE %d) during %s.", label, alg_id, stage
+        )
+
+
+__all__ = [
+    "describe_algorithm",
+    "detect_available_pqc_algorithms",
+    "is_pqc_algorithm",
+    "log_algorithm_selection",
+    "PQC_ALGORITHM_ID_TO_NAME",
+]
+

--- a/tests/test_advanced_algorithms.py
+++ b/tests/test_advanced_algorithms.py
@@ -39,7 +39,14 @@ def client():
 
 def _install_fake_oqs(monkeypatch, algorithms: Sequence[str]) -> None:
     signature = types.SimpleNamespace(algorithms=tuple(algorithms))
-    module = types.SimpleNamespace(Signature=signature)
+
+    def _get_enabled() -> Sequence[str]:
+        return tuple(algorithms)
+
+    module = types.SimpleNamespace(
+        Signature=signature,
+        get_enabled_sig_mechanisms=_get_enabled,
+    )
     monkeypatch.setitem(sys.modules, "oqs", module)
 
 

--- a/tests/test_advanced_algorithms.py
+++ b/tests/test_advanced_algorithms.py
@@ -88,3 +88,43 @@ def test_ignores_invalid_algorithm_entries(client):
 
     assert algorithms == [-50]
     assert all(isinstance(entry["alg"], int) for entry in params)
+
+
+def test_translates_algorithm_names_to_cose_ids(client):
+    data = _post_begin(
+        client,
+        [
+            {"type": "public-key", "alg": "ML-DSA-44"},
+            {"type": "public-key", "alg": "ml-dsa-65"},
+            {"type": "public-key", "alg": "MLDSA87"},
+            {"type": "public-key", "alg": "EdDSA"},
+            {"type": "public-key", "alg": "es256"},
+            {"type": "public-key", "alg": "RSA256"},
+            {"type": "public-key", "alg": "PS256"},
+            {"type": "public-key", "alg": "RS1"},
+        ],
+    )
+
+    params = data["publicKey"]["pubKeyCredParams"]
+    algorithms = [entry["alg"] for entry in params]
+
+    assert algorithms == [-48, -49, -50, -8, -7, -257, -37, -65535]
+    assert all(isinstance(entry["alg"], int) for entry in params)
+
+
+def test_handles_prefixed_algorithm_name_aliases(client):
+    data = _post_begin(
+        client,
+        [
+            {"type": "public-key", "alg": "ML-DSA-44 (PQC) (-48)"},
+            {"type": "public-key", "alg": "FIDOALG-MLDSA65"},
+            {"type": "public-key", "alg": "COSE_ALG_MLDSA87"},
+            {"type": "public-key", "alg": "COSE_ALG_RS256"},
+        ],
+    )
+
+    params = data["publicKey"]["pubKeyCredParams"]
+    algorithms = [entry["alg"] for entry in params]
+
+    assert algorithms == [-48, -49, -50, -257]
+    assert all(isinstance(entry["alg"], int) for entry in params)

--- a/tests/test_pqc_public_key_handling.py
+++ b/tests/test_pqc_public_key_handling.py
@@ -1,0 +1,97 @@
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+for _module_name in [name for name in list(sys.modules) if name == "fido2" or name.startswith("fido2.")]:
+    del sys.modules[_module_name]
+
+import fido2.cose as cose_module  # noqa: E402
+from fido2.cose import MLDSA44, MLDSA65, MLDSA87  # noqa: E402
+
+
+def _build_spki(raw_key: bytes) -> bytes:
+    """Construct a minimal SubjectPublicKeyInfo wrapper for a raw key."""
+
+    def _encode_length(length: int) -> bytes:
+        if length < 0x80:
+            return bytes([length])
+        encoded = length.to_bytes((length.bit_length() + 7) // 8, "big")
+        return bytes([0x80 | len(encoded)]) + encoded
+
+    # Use an arbitrary OID (1.2.3) with a NULL parameters field.
+    oid = b"\x06\x02\x2a\x03"
+    null_params = b"\x05\x00"
+    algorithm = b"\x30" + _encode_length(len(oid) + len(null_params)) + oid + null_params
+    bit_string = b"\x03" + _encode_length(len(raw_key) + 1) + b"\x00" + raw_key
+    spki_body = algorithm + bit_string
+    return b"\x30" + _encode_length(len(spki_body)) + spki_body
+
+def test_mldsa_from_cryptography_key_accepts_raw_public_bytes():
+    raw_key = b"\x01\x02\x03"
+
+    class DummyKey:
+        def public_bytes(self, encoding, fmt):
+            if encoding is serialization.Encoding.Raw and fmt is serialization.PublicFormat.Raw:
+                return raw_key
+            raise ValueError("unexpected encoding")
+
+    cose_key = MLDSA87.from_cryptography_key(DummyKey())
+    assert cose_key[-1] == raw_key
+
+
+def test_mldsa_from_cryptography_key_extracts_from_spki():
+    raw_key = b"raw-public-key"
+    spki = _build_spki(raw_key)
+
+    class DummyKey:
+        def public_bytes(self, encoding, fmt):
+            if encoding is serialization.Encoding.DER and fmt is serialization.PublicFormat.SubjectPublicKeyInfo:
+                return spki
+            raise ValueError("unsupported encoding")
+
+    cose_key = MLDSA65.from_cryptography_key(DummyKey())
+    assert cose_key[-1] == raw_key
+
+
+def test_mldsa_verify_coerces_dynamic_public_key_bytes(monkeypatch):
+    raw_key = b"coerced-public-key"
+    spki = _build_spki(raw_key)
+
+    class DummyKey:
+        def public_bytes(self, encoding, fmt):
+            if encoding is serialization.Encoding.DER and fmt is serialization.PublicFormat.SubjectPublicKeyInfo:
+                return spki
+            raise ValueError("unsupported encoding")
+
+    verify_calls: list[tuple[bytes, bytes, bytes]] = []
+
+    class FakeSignature:
+        def __init__(self, algorithm: str):
+            assert algorithm == "ML-DSA-44"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def verify(self, message: bytes, signature: bytes, public_key: bytes) -> bool:
+            verify_calls.append((message, signature, public_key))
+            return True
+
+    class FakeOQS:
+        Signature = FakeSignature
+
+    monkeypatch.setattr(cose_module, "oqs", FakeOQS)
+    monkeypatch.setattr(cose_module, "_oqs_import_error", None)
+
+    cose_key = MLDSA44({1: 7, 3: -48, -1: DummyKey()})
+    cose_key.verify(b"msg", b"sig")
+
+    assert verify_calls == [(b"msg", b"sig", raw_key)]


### PR DESCRIPTION
## Summary
- coerce custom algorithm identifiers in the advanced registration route so only valid integers are sent to the authenticator
- sanitize the returned options to strip invalid PQC entries while preserving supported values
- add Flask-based tests that confirm string COSE identifiers are normalized and invalid entries ignored

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b1ebce38832cb9e2485326f49df9