### PR TITLE
Allow demo server host configuration

### DIFF
--- a/examples/server/server/app.py
+++ b/examples/server/server/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import pathlib
 import sys
 from types import ModuleType
@@ -44,13 +45,21 @@ def main() -> None:
     if callable(ensure_metadata):
         ensure_metadata(skip_if_reloader_parent=False)
 
+    host = os.environ.get("WEBAUTHN_DEMO_SERVER_HOST", config_module.rp.id or "localhost")
+    port = int(os.environ.get("WEBAUTHN_DEMO_SERVER_PORT", "5000"))
+
+    config_module.configure_relying_party(host)
+
+    ssl_cert = os.environ.get("WEBAUTHN_DEMO_SERVER_CERT", "localhost+1.pem")
+    ssl_key = os.environ.get("WEBAUTHN_DEMO_SERVER_KEY", "localhost+1-key.pem")
+
     # Note: using localhost without TLS, as some browsers do
     # not allow Webauthn in case of TLS certificate errors.
     # See https://lists.w3.org/Archives/Public/public-webauthn/2022Nov/0135.html
     app.run(
-        host="localhost",
-        port=5000,
-        ssl_context=("localhost+1.pem", "localhost+1-key.pem"),
+        host=host,
+        port=port,
+        ssl_context=(ssl_cert, ssl_key),
         debug=True,
     )
 


### PR DESCRIPTION
## Summary
- add a relying-party configuration helper so the demo server can adopt a custom host
- read host/port/SSL overrides from environment variables before starting the Flask app

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4efb48484832c98bd30ea0eda77e7