### PR TITLE
Handle attestation certificate parse failures with fallback serializer

### DIFF
--- a/examples/server/server/attestation.py
+++ b/examples/server/server/attestation.py
@@ -584,11 +584,70 @@ def _extract_common_names(name: x509.Name) -> List[str]:
     return values
 
 
+def _serialize_attestation_certificate_fallback(
+    cert_bytes: bytes, error: Exception
+) -> Dict[str, Any]:
+    """Return certificate metadata when DER parsing fails."""
+
+    der_base64 = base64.b64encode(cert_bytes).decode("ascii")
+    pem_body = "\n".join(textwrap.wrap(der_base64, 64))
+    pem = f"-----BEGIN CERTIFICATE-----\n{pem_body}\n-----END CERTIFICATE-----"
+
+    fingerprints = {
+        "sha256": hashlib.sha256(cert_bytes).hexdigest(),
+        "sha1": hashlib.sha1(cert_bytes).hexdigest(),
+        "md5": hashlib.md5(cert_bytes).hexdigest(),
+    }
+
+    public_key_info, summary_entries = _build_unknown_public_key_info(cert_bytes, error)
+
+    summary_lines = [
+        "Unable to parse attestation certificate using cryptography.x509.",
+        f"Error: {error}",
+        "",
+        f"DER length: {len(cert_bytes)} bytes",
+        "",
+        "Fingerprints:",
+        f"    SHA256: {fingerprints['sha256']}",
+        f"    SHA1: {fingerprints['sha1']}",
+        f"    MD5: {fingerprints['md5']}",
+    ]
+
+    if summary_entries:
+        summary_lines.append("")
+        summary_lines.append("Best-effort public key details:")
+        for label, value in summary_entries:
+            if value in (None, ""):
+                continue
+            if isinstance(value, list):
+                summary_lines.append(f"    {label}:")
+                for item in value:
+                    summary_lines.append(f"        {item}")
+            else:
+                summary_lines.append(f"    {label}: {value}")
+
+    summary = "\n".join(summary_lines).strip()
+
+    return {
+        "error": f"Unable to parse attestation certificate: {error}",
+        "derBase64": der_base64,
+        "fingerprints": fingerprints,
+        "pem": pem,
+        "publicKeyInfo": public_key_info,
+        "raw": cert_bytes.hex(),
+        "summary": summary,
+        "parseError": str(error),
+    }
+
+
 def serialize_attestation_certificate(cert_bytes: bytes):
     if not cert_bytes:
         return None
 
-    certificate = x509.load_der_x509_certificate(cert_bytes)
+    try:
+        certificate = x509.load_der_x509_certificate(cert_bytes)
+    except Exception as exc:  # pragma: no cover - exercised in dedicated tests
+        return _serialize_attestation_certificate_fallback(cert_bytes, exc)
     version_number = certificate.version.value + 1
     version_hex = f"0x{certificate.version.value:x}"
 


### PR DESCRIPTION
## Summary
- add a metadata-focused fallback when cryptography cannot parse an attestation certificate
- wrap certificate loading so the fallback is only used on parse failures without affecting normal paths
- extend the PQC handling tests to cover the new fallback behaviour

## Testing
- pytest tests/test_pqc_public_key_handling.py

------
https://chatgpt.com/codex/tasks/task_e_68d668c3329c832c95f08209cdc0330c