### PR TITLE
Ensure credential public keys persist for assertions

### DIFF
--- a/examples/server/server/routes/simple.py
+++ b/examples/server/server/routes/simple.py
@@ -138,6 +138,11 @@ def register_complete():
         credential_info,
         getattr(auth_data.credential_data, 'public_key', {})
     )
+    add_public_key_material(
+        credential_info['properties'],
+        getattr(auth_data.credential_data, 'public_key', {}),
+        field_prefix='credential',
+    )
 
     if parsed_attestation_object:
         credential_info['attestation_object_decoded'] = make_json_safe(parsed_attestation_object)


### PR DESCRIPTION
## Summary
- ensure COSE public keys are normalised before serialisation and allow prefixed storage fields
- persist credential public key material in advanced and simple registration payloads instead of relying on attestation certificates
- extend PQC handling tests to cover the new storage helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d901b10768832c89e2672659c42c87