### PR TITLE
Fix ML-DSA certificate signature detection in verify_x509_chain

### DIFF
--- a/tests/test_pqc_chain.py
+++ b/tests/test_pqc_chain.py
@@ -72,3 +72,61 @@ def test_verify_x509_chain_uses_ml_dsa(monkeypatch):
     assert signature_recorder["message"] == root_cert.tbs_certificate_bytes
     assert signature_recorder["signature"] == root_cert.signature
     assert signature_recorder["public_key"] == public_key_info["subject_public_key"]
+
+
+def test_verify_x509_chain_preserves_signature_oid(monkeypatch):
+    metadata_path = "examples/server/server/static/feitian-pqc.json"
+    with open(metadata_path, "r", encoding="utf-8") as fh:
+        metadata = json.load(fh)
+
+    root_der = base64.b64decode(metadata["attestationRootCertificates"][0])
+    real_cert = x509.load_der_x509_certificate(root_der, default_backend())
+    public_key_info = extract_certificate_public_key_info(root_der)
+
+    signature_recorder: dict[str, bytes] = {}
+
+    class RecorderSignature(DummySignature):
+        def verify(self, message: bytes, signature: bytes, public_key: bytes) -> bool:
+            signature_recorder.update(
+                {
+                    "parameter_set": self.parameter_set,
+                    "message": bytes(message),
+                    "signature": bytes(signature),
+                    "public_key": bytes(public_key),
+                }
+            )
+            return True
+
+    class MisreportingCertificate:
+        def __init__(self, wrapped: x509.Certificate) -> None:
+            self._wrapped = wrapped
+            self.signature = wrapped.signature
+            self.tbs_certificate_bytes = wrapped.tbs_certificate_bytes
+            self.signature_algorithm_oid = SimpleNamespace(
+                dotted_string="1.2.840.113549.1.1.1"
+            )
+
+        def public_key(self):  # pragma: no cover - defensive fallback
+            raise ValueError("Unknown key type")
+
+    calls = {"count": 0}
+
+    def fake_load_certificate(der: bytes, backend) -> x509.Certificate:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return MisreportingCertificate(real_cert)  # type: ignore[return-value]
+        return real_cert
+
+    monkeypatch.setitem(
+        sys.modules,
+        "oqs",
+        SimpleNamespace(Signature=RecorderSignature),
+    )
+    monkeypatch.setattr(x509, "load_der_x509_certificate", fake_load_certificate)
+
+    verify_x509_chain([root_der, root_der])
+
+    assert signature_recorder["parameter_set"] == "ML-DSA-44"
+    assert signature_recorder["message"] == real_cert.tbs_certificate_bytes
+    assert signature_recorder["signature"] == real_cert.signature
+    assert signature_recorder["public_key"] == public_key_info["subject_public_key"]


### PR DESCRIPTION
## Summary
- parse certificate DER to recover the signatureAlgorithm OID so ML-DSA signatures are preserved
- route ML-DSA signed certificates through oqs verification regardless of cryptography's key-type inference
- add a regression test covering misreported signature OIDs for ML-DSA certificates

## Testing
- pytest tests/test_pqc_chain.py

------
https://chatgpt.com/codex/tasks/task_e_68db2eaa82b0832cb15918aa2f567806